### PR TITLE
badges: do not restrict in step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,4 @@ jobs:
           message-color: ${{ steps.coverage.outputs.badge-color }}
           file-name: coverage.svg
           badge-branch: badges ## orphan branch where badge will be committed
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
```
Error: HttpError: Resource not accessible by integration
```
Go the following error while running the workflow from the commit merged in main.
This was caused by the fact workflow token permission were too restrictive, put it to read-write, should work better now.